### PR TITLE
[JBMETA-458] Add Application Client metadata for Jakarta EE 11Jira is…

### DIFF
--- a/appclient/src/main/resources/schema/application-client_11.xsd
+++ b/appclient/src/main/resources/schema/application-client_11.xsd
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="11">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2024 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application client 10
+      deployment descriptor.  The deployment descriptor must
+      be named "META-INF/application-client.xml" in the
+      application client's jar file.  All application client
+      deployment descriptors must indicate the application
+      client schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd"
+      version="10">
+      ...
+      </application-client>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application-client"
+               type="jakartaee:application-clientType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application-client element is the root element of an
+        application client deployment descriptor.  The application
+        client deployment descriptor describes the enterprise bean 
+        components and external resources referenced by the 
+        application client.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of an
+          application client's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name must
+          be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:unique name="ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an enterprise bean 
+          reference. The enterprise bean reference is an entry 
+          in the application client's environment and is relative to the
+          java:comp/env context. The name must be unique within the
+          application client.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the application client
+          code. The name is a JNDI name relative to the
+          java:comp/env context and must be unique within an
+          application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the
+          name of a message destination reference; its value is
+          the message destination reference name used in the
+          application client code. The name is a JNDI name
+          relative to the java:comp/env context and must be unique
+          within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="application-clientType">
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="callback-handler"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The callback-handler element names a class provided by
+            the application.  The class must have a no args
+            constructor and must implement the
+            jakarta.security.auth.callback.CallbackHandler
+            interface.  The class will be instantiated by the
+            application client container and used by the container
+            to collect authentication information from the user.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="10"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 10.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appclient/src/main/resources/schema/jboss-client_11_0.xsd
+++ b/appclient/src/main/resources/schema/jboss-client_11_0.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source
+~ Copyright 2019, Red Hat, Inc., and individual contributors as indicated
+~ by the @authors tag.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:jboss="urn:jboss:jakartaee:1.0"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            targetNamespace="urn:jboss:jakartaee:1.0"
+            version="11"
+            elementFormDefault="qualified"
+>
+
+    <xsd:annotation>
+        <xsd:documentation>
+            <![CDATA[
+
+    This is the XML Schema for the JBoss 11 application client deployment descriptor.
+    The deployment descriptor must be named "META-INF/jboss-client.xml" in
+    the application client's jar file.  All the application client deployment descriptors must indicate
+    the JBoss schema by using the Jakarta EE namespace:
+
+        urn:jboss:jakartaee:1.0
+
+    and by indicating the version of the schema by
+    using the version attribute as shown below:
+
+        <jboss-client xmlns="urn:jboss:jakartaee:1.0"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="urn:jboss:jakartaee:1.0
+                            https://www.jboss.org/schema/jbossas/jboss-client_11_0.xsd"
+             version="11">
+             ...
+        </jboss-client>
+
+    The instance documents may indicate the published version of
+    the schema using the xsi:schemaLocation attribute for the
+    Jakarta EE namespace with the following location:
+
+        https://www.jboss.org/schema/jbossas/jboss-client_11_0.xsd
+
+    ]]>
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:import namespace="https://jakarta.ee/xml/ns/jakartaee"
+                schemaLocation="https://jakarta.ee/xml/ns/jakartaee/application-client_11.xsd"/>
+    <xsd:include schemaLocation="https://www.jboss.org/schema/jbossas/jboss-common_11_0.xsd"/>
+
+    <xsd:element name="jboss-client" type="jboss:jboss-clientType"/>
+
+    <xsd:complexType name="jboss-clientType">
+        <xsd:sequence>
+            <xsd:element name="module-name" type="xsd:string" minOccurs="0"/>
+            <xsd:group ref="jboss:descriptionGroup"/>
+            <xsd:element name="callback-handler" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="metadata-complete" type="xsd:boolean" minOccurs="0"/>
+            <xsd:element name="jndi-name" type="xsd:string" minOccurs="0"/>
+            <xsd:group ref="jboss:jndiEnvironmentRefsGroup"/>
+            <xsd:element name="message-destinations" type="jboss:message-destinationType" minOccurs="0"
+                         maxOccurs="unbounded"/>
+            <xsd:element name="depends" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:string"/>
+        <xsd:attribute name="version" type="xsd:string"/>
+    </xsd:complexType>
+</xsd:schema>

--- a/appclient/src/main/resources/schema/jboss-client_11_0.xsd
+++ b/appclient/src/main/resources/schema/jboss-client_11_0.xsd
@@ -1,20 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ JBoss, Home of Professional Open Source
-~ Copyright 2019, Red Hat, Inc., and individual contributors as indicated
-~ by the @authors tag.
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~ http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
+  Copyright The JBoss Metadata Authors
+  SPDX-License-Identifier: Apache-2.0
 -->
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/appclient/src/test/java/org/jboss/test/metadata/appclient/AppClient11EverythingUnitTestCase.java
+++ b/appclient/src/test/java/org/jboss/test/metadata/appclient/AppClient11EverythingUnitTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The JBoss Metadata Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.test.metadata.appclient;
+
+import org.jboss.metadata.appclient.parser.spec.ApplicationClientMetaDataParser;
+import org.jboss.metadata.appclient.spec.AppClientEnvironmentRefsGroupMetaData;
+import org.jboss.metadata.appclient.spec.ApplicationClientMetaData;
+import org.jboss.metadata.merge.javaee.spec.JavaEEVersion;
+import org.jboss.test.metadata.javaee.AbstractJavaEEEverythingTest;
+
+/**
+ * App Client 11 everything test.
+ *
+ * @author Eduardo Martins
+ *
+ */
+public class AppClient11EverythingUnitTestCase extends AbstractJavaEEEverythingTest {
+
+    protected ApplicationClientMetaData unmarshal() throws Exception {
+        return ApplicationClientMetaDataParser.INSTANCE.parse(getReader());
+    }
+
+    public void testEverything() throws Exception {
+        // enableTrace("org.jboss.xb");
+        ApplicationClientMetaData result = unmarshal();
+        String prefix = "app";
+        assertEquals("11", result.getVersion());
+        assertEquals(prefix, result.getId());
+        assertTrue(result.isMetadataComplete());
+        assertEquals(prefix + "ModuleName", result.getModuleName());
+        assertDescriptionGroup(prefix, result.getDescriptionGroup());
+        assertEnvironment(prefix, result.getEnvironmentRefsGroupMetaData());
+    }
+
+    protected void assertEnvironment(String prefix, AppClientEnvironmentRefsGroupMetaData env) {
+        assertNotNull(env);
+        final Mode mode = Mode.SPEC;
+        final JavaEEVersion javaEEVersion = JavaEEVersion.V11;
+        assertRemoteEnvironment(prefix, env, true, Descriptor.APPLICATION_CLIENT, mode, javaEEVersion);
+        assertMessageDestinations(2,env.getMessageDestinations(),  mode, javaEEVersion);
+    }
+
+}

--- a/appclient/src/test/java/org/jboss/test/metadata/appclient/AppclientSpecDescriptorTestCase.java
+++ b/appclient/src/test/java/org/jboss/test/metadata/appclient/AppclientSpecDescriptorTestCase.java
@@ -21,7 +21,14 @@ public class AppclientSpecDescriptorTestCase extends SpecDescriptorTestCase {
     @Parameters
     public static List<Object[]> parameters() {
         // The spec descriptor should be guarded in schema
-        return Arrays.asList(new Object[][]{{"schema/application-client_6.xsd"},{"schema/application-client_7.xsd"},{"schema/application-client_8.xsd"},{"schema/application-client_9.xsd"},{"schema/application-client_10.xsd"}});
+        return Arrays.asList(new Object[][]{
+                {"schema/application-client_6.xsd"},
+                {"schema/application-client_7.xsd"},
+                {"schema/application-client_8.xsd"},
+                {"schema/application-client_9.xsd"},
+                {"schema/application-client_10.xsd"},
+                {"schema/application-client_11.xsd"},
+        });
     }
 
     public AppclientSpecDescriptorTestCase(String xsd) {

--- a/appclient/src/test/resources/org/jboss/test/metadata/appclient/AppClient11Everything_testEverything.xml
+++ b/appclient/src/test/resources/org/jboss/test/metadata/appclient/AppClient11Everything_testEverything.xml
@@ -1,0 +1,646 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The JBoss Metadata Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                    https://jakarta.ee/xml/ns/jakartaee/application-client_11.xsd"
+                    version="11" id="app" metadata-complete="true">
+
+    <module-name>appModuleName</module-name>
+
+    <description>en-app-desc</description>
+    <description xml:lang="fr">fr-app-desc</description>
+    <description xml:lang="de">de-app-desc</description>
+    <display-name>en-app-disp</display-name>
+    <display-name xml:lang="fr">fr-app-disp</display-name>
+    <display-name xml:lang="de">de-app-disp</display-name>
+    <icon id="en-app-icon-id">
+        <small-icon>en-app-small-icon</small-icon>
+        <large-icon>en-app-large-icon</large-icon>
+    </icon>
+    <icon xml:lang="fr" id="fr-app-icon-id">
+        <small-icon>fr-app-small-icon</small-icon>
+        <large-icon>fr-app-large-icon</large-icon>
+    </icon>
+    <icon xml:lang="de" id="de-app-icon-id">
+        <small-icon>de-app-small-icon</small-icon>
+        <large-icon>de-app-large-icon</large-icon>
+    </icon>
+
+
+    <env-entry id="appEnvEntry1-id">
+        <description>en-appEnvEntry1-desc</description>
+        <description xml:lang="fr">fr-appEnvEntry1-desc
+        </description>
+        <description xml:lang="de">de-appEnvEntry1-desc
+        </description>
+        <env-entry-name>appEnvEntry1Name</env-entry-name>
+        <env-entry-type>java.lang.String</env-entry-type>
+        <env-entry-value>appEnvEntry1Value</env-entry-value>
+        <mapped-name>appEnvEntry1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appEnvEntry1Injection1Class</injection-target-class>
+            <injection-target-name>appEnvEntry1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appEnvEntry1Injection2Class</injection-target-class>
+            <injection-target-name>appEnvEntry1Injection2Name</injection-target-name>
+        </injection-target>
+    </env-entry>
+    <env-entry id="appEnvEntry2-id">
+        <description>en-appEnvEntry2-desc</description>
+        <description xml:lang="fr">fr-appEnvEntry2-desc
+        </description>
+        <description xml:lang="de">de-appEnvEntry2-desc
+        </description>
+        <env-entry-name>appEnvEntry2Name</env-entry-name>
+        <env-entry-type>java.lang.String</env-entry-type>
+        <env-entry-value>appEnvEntry2Value</env-entry-value>
+        <mapped-name>appEnvEntry2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appEnvEntry2Injection1Class</injection-target-class>
+            <injection-target-name>appEnvEntry2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appEnvEntry2Injection2Class</injection-target-class>
+            <injection-target-name>appEnvEntry2Injection2Name</injection-target-name>
+        </injection-target>
+    </env-entry>
+    <ejb-ref id="appEjbRef1-id">
+        <description>en-appEjbRef1-desc</description>
+        <description xml:lang="fr">fr-appEjbRef1-desc</description>
+        <description xml:lang="de">de-appEjbRef1-desc</description>
+        <ejb-ref-name>appEjbRef1Name</ejb-ref-name>
+        <ejb-ref-type>Session</ejb-ref-type>
+        <home>appEjbRef1Home</home>
+        <remote>appEjbRef1Remote</remote>
+        <ejb-link>appEjbRef1EjbLink</ejb-link>
+        <mapped-name>appEjbRef1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appEjbRef1Injection1Class</injection-target-class>
+            <injection-target-name>appEjbRef1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appEjbRef1Injection2Class</injection-target-class>
+            <injection-target-name>appEjbRef1Injection2Name</injection-target-name>
+        </injection-target>
+    </ejb-ref>
+    <ejb-ref id="appEjbRef2-id">
+        <description>en-appEjbRef2-desc</description>
+        <description xml:lang="fr">fr-appEjbRef2-desc</description>
+        <description xml:lang="de">de-appEjbRef2-desc</description>
+        <ejb-ref-name>appEjbRef2Name</ejb-ref-name>
+        <ejb-ref-type>Entity</ejb-ref-type>
+        <home>appEjbRef2Home</home>
+        <remote>appEjbRef2Remote</remote>
+        <ejb-link>appEjbRef2EjbLink</ejb-link>
+        <mapped-name>appEjbRef2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appEjbRef2Injection1Class</injection-target-class>
+            <injection-target-name>appEjbRef2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appEjbRef2Injection2Class</injection-target-class>
+            <injection-target-name>appEjbRef2Injection2Name</injection-target-name>
+        </injection-target>
+    </ejb-ref>
+
+    <service-ref id="appServiceRef1-id">
+        <description>en-appServiceRef1-desc</description>
+        <description xml:lang="fr">fr-appServiceRef1-desc
+        </description>
+        <description xml:lang="de">de-appServiceRef1-desc
+        </description>
+        <service-ref-name>appServiceRef1Name</service-ref-name>
+        <service-interface>appServiceRef1Iface</service-interface>
+    </service-ref>
+    <service-ref id="appServiceRef2-id">
+        <description>en-appServiceRef2-desc</description>
+        <description xml:lang="fr">fr-appServiceRef2-desc
+        </description>
+        <description xml:lang="de">de-appServiceRef2-desc
+        </description>
+        <service-ref-name>appServiceRef2Name</service-ref-name>
+        <service-interface>appServiceRef2Iface</service-interface>
+    </service-ref>
+
+    <resource-ref id="appResourceRef1-id">
+        <description>en-appResourceRef1-desc</description>
+        <description xml:lang="fr">fr-appResourceRef1-desc
+        </description>
+        <description xml:lang="de">de-appResourceRef1-desc
+        </description>
+        <res-ref-name>appResourceRef1Name</res-ref-name>
+        <res-type>appResourceRef1Type</res-type>
+        <res-auth>Application</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        <mapped-name>appResourceRef1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appResourceRef1Injection1Class</injection-target-class>
+            <injection-target-name>appResourceRef1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appResourceRef1Injection2Class</injection-target-class>
+            <injection-target-name>appResourceRef1Injection2Name</injection-target-name>
+        </injection-target>
+    </resource-ref>
+    <resource-ref id="appResourceRef2-id">
+        <description>en-appResourceRef2-desc</description>
+        <description xml:lang="fr">fr-appResourceRef2-desc
+        </description>
+        <description xml:lang="de">de-appResourceRef2-desc
+        </description>
+        <res-ref-name>appResourceRef2Name</res-ref-name>
+        <res-type>appResourceRef2Type</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Unshareable</res-sharing-scope>
+        <mapped-name>appResourceRef2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appResourceRef2Injection1Class</injection-target-class>
+            <injection-target-name>appResourceRef2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appResourceRef2Injection2Class</injection-target-class>
+            <injection-target-name>appResourceRef2Injection2Name</injection-target-name>
+        </injection-target>
+    </resource-ref>
+    <resource-env-ref id="appResourceEnvRef1-id">
+        <description>en-appResourceEnvRef1-desc</description>
+        <description xml:lang="fr">fr-appResourceEnvRef1-desc
+        </description>
+        <description xml:lang="de">de-appResourceEnvRef1-desc
+        </description>
+        <resource-env-ref-name>appResourceEnvRef1Name</resource-env-ref-name>
+        <resource-env-ref-type>appResourceEnvRef1Type</resource-env-ref-type>
+        <mapped-name>appResourceEnvRef1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appResourceEnvRef1Injection1Class</injection-target-class>
+            <injection-target-name>appResourceEnvRef1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appResourceEnvRef1Injection2Class</injection-target-class>
+            <injection-target-name>appResourceEnvRef1Injection2Name</injection-target-name>
+        </injection-target>
+    </resource-env-ref>
+    <resource-env-ref id="appResourceEnvRef2-id">
+        <description>en-appResourceEnvRef2-desc</description>
+        <description xml:lang="fr">fr-appResourceEnvRef2-desc
+        </description>
+        <description xml:lang="de">de-appResourceEnvRef2-desc
+        </description>
+        <resource-env-ref-name>appResourceEnvRef2Name</resource-env-ref-name>
+        <resource-env-ref-type>appResourceEnvRef2Type</resource-env-ref-type>
+        <mapped-name>appResourceEnvRef2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appResourceEnvRef2Injection1Class</injection-target-class>
+            <injection-target-name>appResourceEnvRef2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appResourceEnvRef2Injection2Class</injection-target-class>
+            <injection-target-name>appResourceEnvRef2Injection2Name</injection-target-name>
+        </injection-target>
+    </resource-env-ref>
+    <message-destination-ref id="appMessageDestinationRef1-id">
+        <description>en-appMessageDestinationRef1-desc</description>
+        <description xml:lang="fr">fr-appMessageDestinationRef1-desc
+        </description>
+        <description xml:lang="de">de-appMessageDestinationRef1-desc
+        </description>
+        <message-destination-ref-name>appMessageDestinationRef1Name</message-destination-ref-name>
+        <message-destination-type>appMessageDestinationRef1Type</message-destination-type>
+        <message-destination-usage>Consumes</message-destination-usage>
+        <message-destination-link>appMessageDestinationRef1Link</message-destination-link>
+        <mapped-name>appMessageDestinationRef1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef1Injection1Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef1Injection2Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef1Injection2Name</injection-target-name>
+        </injection-target>
+    </message-destination-ref>
+    <message-destination-ref id="appMessageDestinationRef2-id">
+        <description>en-appMessageDestinationRef2-desc</description>
+        <description xml:lang="fr">fr-appMessageDestinationRef2-desc
+        </description>
+        <description xml:lang="de">de-appMessageDestinationRef2-desc
+        </description>
+        <message-destination-ref-name>appMessageDestinationRef2Name</message-destination-ref-name>
+        <message-destination-type>appMessageDestinationRef2Type</message-destination-type>
+        <message-destination-usage>Produces</message-destination-usage>
+        <message-destination-link>appMessageDestinationRef2Link</message-destination-link>
+        <mapped-name>appMessageDestinationRef2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef2Injection1Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef2Injection2Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef2Injection2Name</injection-target-name>
+        </injection-target>
+    </message-destination-ref>
+    <message-destination-ref id="appMessageDestinationRef3-id">
+        <description>en-appMessageDestinationRef3-desc</description>
+        <description xml:lang="fr">fr-appMessageDestinationRef3-desc
+        </description>
+        <description xml:lang="de">de-appMessageDestinationRef3-desc
+        </description>
+        <message-destination-ref-name>appMessageDestinationRef3Name</message-destination-ref-name>
+        <message-destination-type>appMessageDestinationRef3Type</message-destination-type>
+        <message-destination-usage>ConsumesProduces</message-destination-usage>
+        <message-destination-link>appMessageDestinationRef3Link</message-destination-link>
+        <mapped-name>appMessageDestinationRef3MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef3Injection1Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef3Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appMessageDestinationRef3Injection2Class</injection-target-class>
+            <injection-target-name>appMessageDestinationRef3Injection2Name</injection-target-name>
+        </injection-target>
+    </message-destination-ref>
+    <persistence-unit-ref id="appPersistenceUnitRef1-id">
+        <description>en-appPersistenceUnitRef1-desc</description>
+        <description xml:lang="fr">fr-appPersistenceUnitRef1-desc
+        </description>
+        <description xml:lang="de">de-appPersistenceUnitRef1-desc
+        </description>
+        <persistence-unit-ref-name>appPersistenceUnitRef1Name</persistence-unit-ref-name>
+        <persistence-unit-name>appPersistenceUnitRef1Unit</persistence-unit-name>
+        <mapped-name>appPersistenceUnitRef1MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appPersistenceUnitRef1Injection1Class</injection-target-class>
+            <injection-target-name>appPersistenceUnitRef1Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appPersistenceUnitRef1Injection2Class</injection-target-class>
+            <injection-target-name>appPersistenceUnitRef1Injection2Name</injection-target-name>
+        </injection-target>
+    </persistence-unit-ref>
+    <persistence-unit-ref id="appPersistenceUnitRef2-id">
+        <description>en-appPersistenceUnitRef2-desc</description>
+        <description xml:lang="fr">fr-appPersistenceUnitRef2-desc
+        </description>
+        <description xml:lang="de">de-appPersistenceUnitRef2-desc
+        </description>
+        <persistence-unit-ref-name>appPersistenceUnitRef2Name</persistence-unit-ref-name>
+        <persistence-unit-name>appPersistenceUnitRef2Unit</persistence-unit-name>
+        <mapped-name>appPersistenceUnitRef2MappedName</mapped-name>
+        <injection-target>
+            <injection-target-class>appPersistenceUnitRef2Injection1Class</injection-target-class>
+            <injection-target-name>appPersistenceUnitRef2Injection1Name</injection-target-name>
+        </injection-target>
+        <injection-target>
+            <injection-target-class>appPersistenceUnitRef2Injection2Class</injection-target-class>
+            <injection-target-name>appPersistenceUnitRef2Injection2Name</injection-target-name>
+        </injection-target>
+    </persistence-unit-ref>
+    <post-construct>
+        <lifecycle-callback-class>appPostConstruct1Class</lifecycle-callback-class>
+        <lifecycle-callback-method>appPostConstruct1Method</lifecycle-callback-method>
+    </post-construct>
+    <post-construct>
+        <lifecycle-callback-class>appPostConstruct2Class</lifecycle-callback-class>
+        <lifecycle-callback-method>appPostConstruct2Method</lifecycle-callback-method>
+    </post-construct>
+    <pre-destroy>
+        <lifecycle-callback-class>appPreDestroy1Class</lifecycle-callback-class>
+        <lifecycle-callback-method>appPreDestroy1Method</lifecycle-callback-method>
+    </pre-destroy>
+    <pre-destroy>
+        <lifecycle-callback-class>appPreDestroy2Class</lifecycle-callback-class>
+        <lifecycle-callback-method>appPreDestroy2Method</lifecycle-callback-method>
+    </pre-destroy>
+    <message-destination id="messageDestination1-id">
+        <description>en-messageDestination1-desc</description>
+        <description xml:lang="fr">fr-messageDestination1-desc
+        </description>
+        <description xml:lang="de">de-messageDestination1-desc
+        </description>
+        <display-name>en-messageDestination1-disp</display-name>
+        <display-name xml:lang="fr">fr-messageDestination1-disp</display-name>
+        <display-name xml:lang="de">de-messageDestination1-disp</display-name>
+        <icon id="en-messageDestination1-icon-id">
+            <small-icon>en-messageDestination1-small-icon</small-icon>
+            <large-icon>en-messageDestination1-large-icon</large-icon>
+        </icon>
+        <icon xml:lang="fr" id="fr-messageDestination1-icon-id">
+            <small-icon>fr-messageDestination1-small-icon</small-icon>
+            <large-icon>fr-messageDestination1-large-icon</large-icon>
+        </icon>
+        <icon xml:lang="de" id="de-messageDestination1-icon-id">
+            <small-icon>de-messageDestination1-small-icon</small-icon>
+            <large-icon>de-messageDestination1-large-icon</large-icon>
+        </icon>
+        <message-destination-name>messageDestination1Name</message-destination-name>
+        <mapped-name>messageDestination1MappedName</mapped-name>
+        <lookup-name>messageDestination1LookupName</lookup-name>
+    </message-destination>
+    <message-destination id="messageDestination2-id">
+        <description>en-messageDestination2-desc</description>
+        <description xml:lang="fr">fr-messageDestination2-desc
+        </description>
+        <description xml:lang="de">de-messageDestination2-desc
+        </description>
+        <display-name>en-messageDestination2-disp</display-name>
+        <display-name xml:lang="fr">fr-messageDestination2-disp</display-name>
+        <display-name xml:lang="de">de-messageDestination2-disp</display-name>
+        <icon id="en-messageDestination2-icon-id">
+            <small-icon>en-messageDestination2-small-icon</small-icon>
+            <large-icon>en-messageDestination2-large-icon</large-icon>
+        </icon>
+        <icon xml:lang="fr" id="fr-messageDestination2-icon-id">
+            <small-icon>fr-messageDestination2-small-icon</small-icon>
+            <large-icon>fr-messageDestination2-large-icon</large-icon>
+        </icon>
+        <icon xml:lang="de" id="de-messageDestination2-icon-id">
+            <small-icon>de-messageDestination2-small-icon</small-icon>
+            <large-icon>de-messageDestination2-large-icon</large-icon>
+        </icon>
+        <message-destination-name>messageDestination2Name</message-destination-name>
+        <mapped-name>messageDestination2MappedName</mapped-name>
+        <lookup-name>messageDestination2LookupName</lookup-name>
+    </message-destination>
+
+    <data-source>
+        <description>en-appDataSource1-desc</description>
+        <name>appDataSource1Name</name>
+        <class-name>appDataSource1ClassName</class-name>
+        <server-name>appDataSource1ServerName</server-name>
+        <port-number>1</port-number>
+        <database-name>appDataSource1DatabaseName</database-name>
+        <url>jdbc:appDataSource1:url</url>
+        <user>appDataSource1User</user>
+        <password>appDataSource1Password</password>
+        <property id="appDataSource1Property1-id">
+            <name>appDataSource1Property1Name</name>
+            <value>appDataSource1Property1Value</value>
+        </property>
+        <property id="appDataSource1Property2-id">
+            <name>appDataSource1Property2Name</name>
+            <value>appDataSource1Property2Value</value>
+        </property>
+        <login-timeout>1</login-timeout>
+        <transactional>false</transactional>
+        <isolation-level>TRANSACTION_READ_UNCOMMITTED</isolation-level>
+        <initial-pool-size>1</initial-pool-size>
+        <max-pool-size>1</max-pool-size>
+        <min-pool-size>1</min-pool-size>
+        <max-idle-time>1</max-idle-time>
+        <max-statements>1</max-statements>
+    </data-source>
+    <data-source>
+        <description>en-appDataSource2-desc</description>
+        <name>appDataSource2Name</name>
+        <class-name>appDataSource2ClassName</class-name>
+        <server-name>appDataSource2ServerName</server-name>
+        <port-number>2</port-number>
+        <database-name>appDataSource2DatabaseName</database-name>
+        <url>jdbc:appDataSource2:url</url>
+        <user>appDataSource2User</user>
+        <password>appDataSource2Password</password>
+        <property id="appDataSource2Property1-id">
+            <name>appDataSource2Property1Name</name>
+            <value>appDataSource2Property1Value</value>
+        </property>
+        <property id="appDataSource2Property2-id">
+            <name>appDataSource2Property2Name</name>
+            <value>appDataSource2Property2Value</value>
+        </property>
+        <login-timeout>2</login-timeout>
+        <transactional>true</transactional>
+        <isolation-level>TRANSACTION_READ_COMMITTED</isolation-level>
+        <initial-pool-size>2</initial-pool-size>
+        <max-pool-size>2</max-pool-size>
+        <min-pool-size>2</min-pool-size>
+        <max-idle-time>2</max-idle-time>
+        <max-statements>2</max-statements>
+    </data-source>
+
+    <!-- javaee:7:jms-connection-factory -->
+    <jms-connection-factory>
+        <description>appJmsConnectionFactory1Desc</description>
+        <name>appJmsConnectionFactory1Name</name>
+        <interface-name>javax.jms.QueueConnectionFactory</interface-name>
+        <class-name>appJmsConnectionFactory1ClassName</class-name>
+        <resource-adapter>appJmsConnectionFactory1ResourceAdapter</resource-adapter>
+        <user>appJmsConnectionFactory1User</user>
+        <password>appJmsConnectionFactory1Password</password>
+        <client-id>appJmsConnectionFactory1ClientId</client-id>
+        <property id="appJmsConnectionFactory1Property1-id">
+            <name>appJmsConnectionFactory1Property1Name</name>
+            <value>appJmsConnectionFactory1Property1Value</value>
+        </property>
+        <property id="appJmsConnectionFactory1Property2-id">
+            <name>appJmsConnectionFactory1Property2Name</name>
+            <value>appJmsConnectionFactory1Property2Value</value>
+        </property>
+        <transactional>true</transactional>
+        <max-pool-size>1</max-pool-size>
+        <min-pool-size>1</min-pool-size>
+    </jms-connection-factory>
+    <jms-connection-factory>
+        <description>appJmsConnectionFactory2Desc</description>
+        <name>appJmsConnectionFactory2Name</name>
+        <interface-name>javax.jms.TopicConnectionFactory</interface-name>
+        <class-name>appJmsConnectionFactory2ClassName</class-name>
+        <resource-adapter>appJmsConnectionFactory2ResourceAdapter</resource-adapter>
+        <user>appJmsConnectionFactory2User</user>
+        <password>appJmsConnectionFactory2Password</password>
+        <client-id>appJmsConnectionFactory2ClientId</client-id>
+        <property id="appJmsConnectionFactory2Property1-id">
+            <name>appJmsConnectionFactory2Property1Name</name>
+            <value>appJmsConnectionFactory2Property1Value</value>
+        </property>
+        <property id="appJmsConnectionFactory2Property2-id">
+            <name>appJmsConnectionFactory2Property2Name</name>
+            <value>appJmsConnectionFactory2Property2Value</value>
+        </property>
+        <transactional>false</transactional>
+        <max-pool-size>2</max-pool-size>
+        <min-pool-size>2</min-pool-size>
+    </jms-connection-factory>
+    <jms-connection-factory>
+        <name>appJmsConnectionFactory3Name</name>
+    </jms-connection-factory>
+    <!-- javaee:7:jms-destination -->
+    <jms-destination>
+        <description>appJmsDestination1Desc</description>
+        <name>appJmsDestination1Name</name>
+        <interface-name>javax.jms.Queue</interface-name>
+        <class-name>appJmsDestination1ClassName</class-name>
+        <resource-adapter>appJmsDestination1ResourceAdapter</resource-adapter>
+        <destination-name>appJmsDestination1DestinationName</destination-name>
+        <property id="appJmsDestination1Property1-id">
+            <name>appJmsDestination1Property1Name</name>
+            <value>appJmsDestination1Property1Value</value>
+        </property>
+        <property id="appJmsDestination1Property2-id">
+            <name>appJmsDestination1Property2Name</name>
+            <value>appJmsDestination1Property2Value</value>
+        </property>
+    </jms-destination>
+    <jms-destination>
+        <description>appJmsDestination2Desc</description>
+        <name>appJmsDestination2Name</name>
+        <interface-name>javax.jms.Queue</interface-name>
+        <class-name>appJmsDestination2ClassName</class-name>
+        <resource-adapter>appJmsDestination2ResourceAdapter</resource-adapter>
+        <destination-name>appJmsDestination2DestinationName</destination-name>
+        <property id="appJmsDestination2Property1-id">
+            <name>appJmsDestination2Property1Name</name>
+            <value>appJmsDestination2Property1Value</value>
+        </property>
+        <property id="appJmsDestination2Property2-id">
+            <name>appJmsDestination2Property2Name</name>
+            <value>appJmsDestination2Property2Value</value>
+        </property>
+    </jms-destination>
+    <jms-destination>
+        <name>appJmsDestination3Name</name>
+        <interface-name>javax.jms.Topic</interface-name>
+    </jms-destination>
+    <!-- javaee:7:mail-session -->
+    <mail-session>
+        <description>appMailSession1Desc</description>
+        <name>appMailSession1Name</name>
+        <store-protocol>appMailSession1StoreProtocol</store-protocol>
+        <store-protocol-class>appMailSession1StoreProtocolClass</store-protocol-class>
+        <transport-protocol>appMailSession1TransportProtocol</transport-protocol>
+        <transport-protocol-class>appMailSession1TransportProtocolClass</transport-protocol-class>
+        <host>appMailSession1Host</host>
+        <user>appMailSession1User</user>
+        <password>appMailSession1Password</password>
+        <from>appMailSession1From</from>
+        <property id="appMailSession1Property1-id">
+            <name>appMailSession1Property1Name</name>
+            <value>appMailSession1Property1Value</value>
+        </property>
+        <property id="appMailSession1Property2-id">
+            <name>appMailSession1Property2Name</name>
+            <value>appMailSession1Property2Value</value>
+        </property>
+    </mail-session>
+    <mail-session>
+        <description>appMailSession2Desc</description>
+        <name>appMailSession2Name</name>
+        <store-protocol>appMailSession2StoreProtocol</store-protocol>
+        <store-protocol-class>appMailSession2StoreProtocolClass</store-protocol-class>
+        <transport-protocol>appMailSession2TransportProtocol</transport-protocol>
+        <transport-protocol-class>appMailSession2TransportProtocolClass</transport-protocol-class>
+        <host>appMailSession2Host</host>
+        <user>appMailSession2User</user>
+        <password>appMailSession2Password</password>
+        <from>appMailSession2From</from>
+        <property id="appMailSession2Property1-id">
+            <name>appMailSession2Property1Name</name>
+            <value>appMailSession2Property1Value</value>
+        </property>
+        <property id="appMailSession2Property2-id">
+            <name>appMailSession2Property2Name</name>
+            <value>appMailSession2Property2Value</value>
+        </property>
+    </mail-session>
+    <mail-session>
+        <name>appMailSession3Name</name>
+    </mail-session>
+    <!-- javaee:7:connection-factory -->
+    <connection-factory>
+        <description>appConnectionFactory1Desc</description>
+        <name>appConnectionFactory1Name</name>
+        <interface-name>appConnectionFactory1InterfaceName</interface-name>
+        <resource-adapter>appConnectionFactory1ResourceAdapter</resource-adapter>
+        <max-pool-size>1</max-pool-size>
+        <min-pool-size>1</min-pool-size>
+        <transaction-support>NoTransaction</transaction-support>
+        <property id="appConnectionFactory1Property1-id">
+            <name>appConnectionFactory1Property1Name</name>
+            <value>appConnectionFactory1Property1Value</value>
+        </property>
+        <property id="appConnectionFactory1Property2-id">
+            <name>appConnectionFactory1Property2Name</name>
+            <value>appConnectionFactory1Property2Value</value>
+        </property>
+    </connection-factory>
+    <connection-factory>
+        <description>appConnectionFactory2Desc</description>
+        <name>appConnectionFactory2Name</name>
+        <interface-name>appConnectionFactory2InterfaceName</interface-name>
+        <resource-adapter>appConnectionFactory2ResourceAdapter</resource-adapter>
+        <max-pool-size>2</max-pool-size>
+        <min-pool-size>2</min-pool-size>
+        <transaction-support>LocalTransaction</transaction-support>
+        <property id="appConnectionFactory2Property1-id">
+            <name>appConnectionFactory2Property1Name</name>
+            <value>appConnectionFactory2Property1Value</value>
+        </property>
+        <property id="appConnectionFactory2Property2-id">
+            <name>appConnectionFactory2Property2Name</name>
+            <value>appConnectionFactory2Property2Value</value>
+        </property>
+    </connection-factory>
+    <connection-factory>
+        <description>appConnectionFactory3Desc</description>
+        <name>appConnectionFactory3Name</name>
+        <interface-name>appConnectionFactory3InterfaceName</interface-name>
+        <resource-adapter>appConnectionFactory3ResourceAdapter</resource-adapter>
+        <max-pool-size>3</max-pool-size>
+        <min-pool-size>3</min-pool-size>
+        <transaction-support>XATransaction</transaction-support>
+        <property id="appConnectionFactory3Property1-id">
+            <name>appConnectionFactory3Property1Name</name>
+            <value>appConnectionFactory3Property1Value</value>
+        </property>
+        <property id="appConnectionFactory3Property2-id">
+            <name>appConnectionFactory3Property2Name</name>
+            <value>appConnectionFactory3Property2Value</value>
+        </property>
+    </connection-factory>
+    <connection-factory>
+        <name>appConnectionFactory4Name</name>
+        <interface-name>appConnectionFactory4InterfaceName</interface-name>
+        <resource-adapter>appConnectionFactory4ResourceAdapter</resource-adapter>
+    </connection-factory>
+    <!-- javaee:7:administered-object -->
+    <administered-object>
+        <description>appAdministeredObject1Desc</description>
+        <name>appAdministeredObject1Name</name>
+        <interface-name>appAdministeredObject1InterfaceName</interface-name>
+        <class-name>appAdministeredObject1ClassName</class-name>
+        <resource-adapter>appAdministeredObject1ResourceAdapter</resource-adapter>
+        <property id="appAdministeredObject1Property1-id">
+            <name>appAdministeredObject1Property1Name</name>
+            <value>appAdministeredObject1Property1Value</value>
+        </property>
+        <property id="appAdministeredObject1Property2-id">
+            <name>appAdministeredObject1Property2Name</name>
+            <value>appAdministeredObject1Property2Value</value>
+        </property>
+    </administered-object>
+    <administered-object>
+        <description>appAdministeredObject2Desc</description>
+        <name>appAdministeredObject2Name</name>
+        <interface-name>appAdministeredObject2InterfaceName</interface-name>
+        <class-name>appAdministeredObject2ClassName</class-name>
+        <resource-adapter>appAdministeredObject2ResourceAdapter</resource-adapter>
+        <property id="appAdministeredObject2Property1-id">
+            <name>appAdministeredObject2Property1Name</name>
+            <value>appAdministeredObject2Property1Value</value>
+        </property>
+        <property id="appAdministeredObject2Property2-id">
+            <name>appAdministeredObject2Property2Name</name>
+            <value>appAdministeredObject2Property2Value</value>
+        </property>
+    </administered-object>
+    <administered-object>
+        <name>appAdministeredObject3Name</name>
+        <class-name>appAdministeredObject3ClassName</class-name>
+        <resource-adapter>appAdministeredObject3ResourceAdapter</resource-adapter>
+    </administered-object>
+
+</application-client>

--- a/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
+++ b/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
@@ -99,6 +99,7 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application-client_8.xsd", "application-client_8.xsd");
         registerEntity("https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd", "application-client_9.xsd");
         registerEntity("https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd", "application-client_10.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/application-client_11.xsd", "application-client_11.xsd");
 
         // jboss-client
         registerEntity("-//JBoss//DTD Application Client 3.2//EN", "jboss-client_3_2.dtd");

--- a/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
+++ b/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
@@ -83,6 +83,7 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd", "application_8.xsd");
         registerEntity("https://jakarta.ee/xml/ns/jakartaee/application_9.xsd", "application_9.xsd");
         registerEntity("https://jakarta.ee/xml/ns/jakartaee/application_10.xsd", "application_10.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/application_11.xsd", "application_11.xsd");
 
         // jboss-app
         registerEntity("-//JBoss//DTD J2EE Application 1.3//EN", "jboss-app_3_0.dtd");

--- a/common/src/main/resources/schema/jboss-common_11_0.xsd
+++ b/common/src/main/resources/schema/jboss-common_11_0.xsd
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source
+~ Copyright 2022, Red Hat, Inc., and individual contributors as indicated
+~ by the @authors tag.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:jakartaee:1.0"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jboss="urn:jboss:jakartaee:1.0"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="11.0">
+   <xsd:annotation>
+      <xsd:documentation>
+         <![CDATA[
+
+         This XML Schema defines types, elements and model groups that common to all application-specific JBoss schemas.
+         The target namespace is
+
+            urn:jboss:jakartaee:1.0
+
+         Online URL https://www.jboss.org/schema/jbossas/jboss-common_11_0.xsd
+         ]]>
+      </xsd:documentation>
+   </xsd:annotation>
+
+   <xsd:annotation>
+      <xsd:documentation> The following conventions apply to all Jakarta EE deployment descriptor
+         elements unless indicated otherwise. - In elements that specify a pathname to a file within
+         the same JAR file, relative filenames (i.e., those not starting with "/") are considered
+         relative to the root of the JAR file's namespace. Absolute filenames (i.e., those starting
+         with "/") also specify names in the root of the JAR file's namespace. In general, relative
+         names are preferred. The exception is .war files where absolute names are preferred for
+         consistency with the Servlet API. </xsd:documentation>
+   </xsd:annotation>
+
+   <xsd:import namespace="https://jakarta.ee/xml/ns/jakartaee" schemaLocation="https://jakarta.ee/xml/ns/jakartaee/jakartaee_11.xsd"/>
+
+   <xsd:group name="descriptionGroup">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="display-name" type="jakartaee:display-nameType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="icon" type="jakartaee:iconType" minOccurs="0" maxOccurs="unbounded" />
+      </xsd:sequence>
+   </xsd:group>
+
+   <xsd:group name="jndiEnvironmentRefsGroup">
+      <xsd:sequence>
+         <xsd:element name="env-entry" type="jboss:env-entryType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="ejb-ref" type="jboss:ejb-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="ejb-local-ref" type="jboss:ejb-local-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:group ref="jboss:service-refGroup" />
+         <xsd:element name="resource-ref" type="jboss:resource-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="resource-env-ref" type="jboss:resource-env-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="message-destination-ref" type="jboss:message-destination-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="persistence-context-ref" type="jboss:persistence-context-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="persistence-unit-ref" type="jboss:persistence-unit-refType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="post-construct" type="jboss:lifecycle-callbackType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="pre-destroy" type="jboss:lifecycle-callbackType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="data-source" type="jboss:data-sourceType" minOccurs="0" maxOccurs="unbounded" />
+      </xsd:sequence>
+   </xsd:group>
+
+   <xsd:complexType name="env-entryType">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="env-entry-name" type="jakartaee:jndi-nameType" />
+         <xsd:element name="env-entry-type" type="jakartaee:env-entry-type-valuesType" minOccurs="0" />
+         <xsd:element name="env-entry-value" type="jakartaee:xsdStringType" minOccurs="0" />
+         <xsd:group ref="jboss:resourceGroup" />
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+   <xsd:complexType name="injection-targetType">
+      <xsd:sequence>
+         <xsd:element name="injection-target-class" type="jakartaee:fully-qualified-classType" />
+         <xsd:element name="injection-target-name" type="jakartaee:java-identifierType" />
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="lifecycle-callbackType">
+      <xsd:sequence>
+         <xsd:element name="lifecycle-callback-class" type="jakartaee:fully-qualified-classType" minOccurs="0" />
+         <xsd:element name="lifecycle-callback-method" type="jakartaee:java-identifierType" />
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="message-destination-refType">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="message-destination-ref-name" type="jakartaee:jndi-nameType"/>
+         <xsd:element name="message-destination-type" type="jakartaee:message-destination-typeType" minOccurs="0" />
+         <xsd:element name="message-destination-usage" type="jakartaee:message-destination-usageType" minOccurs="0" />
+         <xsd:element name="message-destination-link" type="jakartaee:message-destination-linkType" minOccurs="0" />
+         <xsd:group ref="jboss:resourceGroup" />
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+   <!-- Bring persistence-context-refType info jboss namespace -->
+   <xsd:complexType name="persistence-context-refType">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="persistence-context-ref-name" type="jakartaee:jndi-nameType" />
+         <xsd:element name="persistence-unit-name" type="jakartaee:string" minOccurs="0" />
+         <xsd:element name="persistence-context-type" type="jakartaee:persistence-context-typeType" minOccurs="0" />
+         <xsd:element name="persistence-property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:group ref="jboss:resourceGroup" />
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+   <xsd:complexType name="persistence-unit-refType">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="persistence-unit-ref-name" type="jakartaee:jndi-nameType" />
+         <xsd:element name="persistence-unit-name" type="jakartaee:string" minOccurs="0" />
+         <xsd:group ref="jboss:resourceGroup" />
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+   <xsd:complexType name="resource-env-refType">
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="resource-env-ref-name" type="jakartaee:jndi-nameType" />
+         <xsd:element name="resource-env-ref-type" type="jakartaee:fully-qualified-classType" minOccurs="0" />
+         <xsd:group ref="jboss:resourceGroup" />
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" />
+      <xsd:element name="name" type="jakartaee:jndi-nameType" />
+      <xsd:element name="class-name" type="jakartaee:fully-qualified-classType" minOccurs="0" />
+      <xsd:element name="server-name" type="jakartaee:string" minOccurs="0" />
+      <xsd:element name="port-number" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="database-name" type="jakartaee:string" minOccurs="0" />
+      <xsd:element name="url" type="jakartaee:jdbc-urlType" minOccurs="0" />
+      <xsd:element name="user" type="jakartaee:string" minOccurs="0" />
+      <xsd:element name="password" type="jakartaee:string" minOccurs="0" />
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="login-timeout" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="transactional" type="jakartaee:xsdBooleanType" minOccurs="0" />
+      <xsd:element name="isolation-level" type="jakartaee:isolation-levelType" minOccurs="0" />
+      <xsd:element name="initial-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="max-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="min-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="max-idle-time" type="jakartaee:xsdIntegerType" minOccurs="0" />
+      <xsd:element name="max-statements" type="jakartaee:xsdIntegerType" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <xsd:group name="resourceGroup">
+      <xsd:sequence>
+         <!-- In jboss xml we allow the use of jndi-name instead of mapped-name -->
+         <xsd:choice minOccurs="0">
+            <xsd:element name="jndi-name" type="jakartaee:jndi-nameType"/>
+            <xsd:element name="mapped-name" type="jakartaee:xsdStringType"/>
+         </xsd:choice>
+         <xsd:element name="injection-target" type="jboss:injection-targetType" minOccurs="0" maxOccurs="unbounded" />
+         <xsd:element name="ignore-dependency" type="jakartaee:emptyType" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+
+   <xsd:group name="service-refGroup">
+      <xsd:sequence>
+         <xsd:element name="service-ref" type="jboss:service-refType" minOccurs="0" maxOccurs="unbounded">
+            <xsd:key name="service-ref_handler-name-key">
+               <xsd:selector xpath="jakartaee:handler" />
+               <xsd:field xpath="jakartaee:handler-name" />
+            </xsd:key>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:group>
+
+  <xsd:complexType name="jndi-binding-policyType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The jndiBindingPolicyType defines the fully-qualified name of
+	  a class that implements the JNDI binding policy.
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+   <xsd:complexType name="jmx-nameType">
+      <xsd:annotation>
+         <xsd:documentation> The jmx-name element allows one to specify the JMX ObjectName to use for
+            the MBean associated with the ejb-jar module. This must be a unique name and valid JMX
+            ObjectName string. </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="security-domainType">
+      <xsd:annotation>
+         <xsd:documentation> The security-domain element specifies the JNDI name of the security
+            manager that implements the EJBSecurityManager and RealmMapping for the domain. When
+            specified at the jboss level it specifies the security domain for all Jakarta EE components in the
+            deployment unit. One can override the global security-domain at the container level using
+            the security-domain element at the container-configuration level. </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="security-roleType">
+      <xsd:annotation>
+         <xsd:documentation> The security-role element contains the definition of a security role.
+            The definition consists of an the security role name and principal name element(s). </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="description"
+            type="jakartaee:descriptionType"
+            minOccurs="0"
+            maxOccurs="unbounded"/>
+         <xsd:element name="role-name"
+            type="jakartaee:role-nameType"/>
+         <xsd:element name="principal-name" type="jboss:principal-nameType" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="principal-nameType">
+      <xsd:annotation>
+         <xsd:documentation> The principal-name element is the name of the principal that is mapped
+            to the assembly role-name. </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="dependsType">
+      <xsd:annotation>
+         <xsd:documentation> The depends element gives a JMX ObjectName of a service on which the
+            container or ejb depends. (default) </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="local-jndi-nameType">
+      <xsd:annotation>
+         <xsd:documentation> The JNDI name under with the local interface should be bound. If it is not
+            provided jboss will assume "jndi-name" = "beanClass/local" </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="ejb-refType">
+      <xsd:annotation>
+         <xsd:documentation> The ejb-ref element is used to give the jndi-name of an external ejb
+            reference. In the case of an external ejb reference, you don't provide a ejb-link element in
+            ejb-jar.xml, but you provide a jndi-name in jboss.xml Used in: entity, session,
+            message-driven, consumer, and service </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="ejb-ref-name" type="jakartaee:ejb-ref-nameType" minOccurs="0"/>
+         <xsd:element name="ejb-ref-type" type="jakartaee:ejb-ref-typeType" minOccurs="0"/>
+         <xsd:element name="home" type="jakartaee:homeType" minOccurs="0"/>
+         <xsd:element name="remote" type="jakartaee:remoteType" minOccurs="0"/>
+         <xsd:element name="ejb-link" type="jakartaee:ejb-linkType" minOccurs="0"/>
+         <xsd:group ref="jboss:resourceGroup"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+
+   </xsd:complexType>
+
+   <xsd:complexType name="ejb-local-refType">
+      <xsd:annotation>
+         <xsd:documentation> The ejb-local-ref element is used to give the jndi-name of an external ejb
+            reference. In the case of an external ejb reference, you don't provide a ejb-link element in
+            ejb-jar.xml, but you provide a jndi-name in jboss.xml </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="ejb-ref-name" type="jakartaee:ejb-ref-nameType" minOccurs="0"/>
+         <xsd:element name="ejb-ref-type" type="jakartaee:ejb-ref-typeType" minOccurs="0"/>
+         <xsd:element name="local-home" type="jakartaee:local-homeType" minOccurs="0"/>
+         <xsd:element name="local" type="jakartaee:localType" minOccurs="0"/>
+         <xsd:element name="ejb-link" type="jakartaee:ejb-linkType" minOccurs="0"/>
+         <xsd:element name="local-jndi-name" type="jakartaee:jndi-nameType" minOccurs="0"/>
+         <xsd:group ref="jboss:resourceGroup"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="resource-refType">
+      <xsd:annotation>
+         <xsd:documentation> The resource-ref element gives a mapping between the "code name" of a
+            resource (res-ref-name, provided by the Bean Developer) and its "xml name" (resource-name,
+            provided by the Application Assembler). If no resource-ref is provided, jboss will assume
+            that "xml-name" = "code name" See resource-managers. </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="res-ref-name" type="jakartaee:jndi-nameType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation> The res-ref-name element specifies the name of a resource manager
+                  connection factory reference. The name is a JNDI name relative to the java:comp/env
+                  context. The name must be unique within a Deployment File. </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="res-type" type="jakartaee:fully-qualified-classType" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation> The res-type element specifies the type of the data source. The type
+                  is specified by the fully qualified Java language class or interface expected to be
+                  implemented by the data source. </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="res-auth" type="jakartaee:res-authType" minOccurs="0"/>
+
+         <xsd:element name="res-sharing-scope" type="jakartaee:res-sharing-scopeType" minOccurs="0"/>
+
+         <!-- We redefine part of the resourceGroup here, so we can't ref it -->
+         <xsd:choice>
+            <xsd:element name="resource-name" type="jakartaee:xsdStringType"/>
+            <xsd:element name="jndi-name" type="jakartaee:xsdStringType"/>
+            <xsd:element name="mapped-name" type="jakartaee:xsdStringType"/>
+            <xsd:element name="res-url" type="jakartaee:xsdStringType"/>
+         </xsd:choice>
+
+         <xsd:element name="injection-target" type="jboss:injection-targetType" minOccurs="0" maxOccurs="unbounded" />
+
+         <xsd:element name="ignore-dependency" type="jakartaee:emptyType" minOccurs="0"/>
+
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="service-ref-nameType">
+      <xsd:annotation>
+         <xsd:documentation> The service-ref-name element gives the ENC relative name used in the
+            ejb-jar.xml service-ref-name element. </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:restriction base="jakartaee:string"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="loader-repositoryType" mixed="true">
+      <xsd:annotation>
+         <xsd:documentation>
+            <![CDATA[
+      The loader-repository specifies the name of the UnifiedLoaderRepository
+   MBean to use for the ear to provide ear level scoping of classes deployed
+   in the ear. It is a unique JMX ObjectName string. It may also specify
+   an arbitrary configuration by including a loader-repository-config element.
+
+Examples:
+   <loader-repository>jboss.test:loader=cts-cmp2v1-sar.ear</loader-repository>
+
+   <loader-repository loaderRepositoryClass='dot.com.LoaderRepository'>
+      dot.com:loader=unique-archive-name
+      <loader-repository-config configParserClass='dot.com.LoaderParser'>
+         java2ParentDelegaton=true
+      </loader-repository-config>
+   </loader-repository>
+        </loader-repository>
+        ]]>
+         </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:element name="loader-repository-config" type="jboss:loader-repository-configType"
+                      minOccurs="0" maxOccurs="unbounded"/>
+
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+      <xsd:attribute name="loaderRepositoryClass" type="xsd:string"/>
+   </xsd:complexType>
+
+   <!-- **************************************************** -->
+
+   <xsd:complexType name="loader-repository-configType" mixed="true">
+      <xsd:annotation>
+         <xsd:documentation> The loader-repository-config element specifies any arbitrary configuration
+            fragment for use in configuring the loader-repository instance. The actual content of this
+            element is specific to the loaderRepositoryClass and the code parsing the element.
+         </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:attribute name="id" type="xsd:ID"/>
+      <xsd:attribute name="configParserClass" type="xsd:string"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="service-refType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <![CDATA[
+  Runtime settings for a web service reference. In the simplest case,
+  there is no runtime information required for a service ref.  Runtime info
+  is only needed in the following cases :
+
+  * to define the port that should be used to resolve a container-managed port
+  * to define default Stub property settings for Stub objects
+  * to define the URL of a final WSDL document to be used
+
+  Example:
+
+  <service-ref>
+   <service-ref-name>OrganizationService</service-ref-name>
+   <wsdl-override>file:/wsdlRepository/organization-service.wsdl</wsdl-override>
+  </service-ref>
+
+  <service-ref>
+   <service-ref-name>OrganizationService</service-ref-name>
+   <config-name>Secure Client Config</config-name>
+   <config-file>META-INF/jbossws-client-config.xml</config-file>
+   <handler-chain>META-INF/jbossws-client-handlers.xml</handler-chain>
+  </service-ref>
+
+  <service-ref>
+   <service-ref-name>SecureService</service-ref-name>
+   <service-impl-class>org.jboss.tests.ws.jaxws.webserviceref.SecureEndpointService</service-impl-class>
+   <service-qname>{http://org.jboss.ws/wsref}SecureEndpointService</service-qname>
+    <port-component-ref>
+     <service-endpoint-interface>org.jboss.tests.ws.jaxws.webserviceref.SecureEndpoint</service-endpoint-interface>
+     <port-qname>{http://org.jboss.ws/wsref}SecureEndpointPort</port-qname>
+     <stub-property>
+      <name>javax.xml.ws.security.auth.username</name>
+      <value>kermit</value>
+     </stub-property>
+     <stub-property>
+      <name>javax.xml.ws.security.auth.password</name>
+      <value>thefrog</value>
+     </stub-property>
+   </port-component-ref>
+  </service-ref>
+    ]]>
+         </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:element name="service-ref-name" type="xsd:string"/>
+         <xsd:element name="service-impl-class" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="service-qname" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="config-name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="config-file" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="handler-chain" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="port-component-ref" type="jboss:port-component-refType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="wsdl-override" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <!--
+     Information for a port within a service-ref.
+
+     Either service-endpoint-interface or wsdl-port or both
+     (service-endpoint-interface and wsdl-port) should be specified.
+
+     If both are specified, wsdl-port represents the
+     port the container should choose for container-managed port selection.
+
+     The same wsdl-port value must not appear in
+     more than one port-component-ref entry within the same service-ref.
+
+     If a particular service-endpoint-interface is using container-managed port
+     selection, it must not appear in more than one port-component-ref entry
+     within the same service-ref.
+   -->
+   <xsd:complexType name="port-component-refType">
+      <xsd:sequence>
+         <xsd:element name="service-endpoint-interface" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="port-qname" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="config-name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="config-file" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="stub-property" type="jboss:stub-propertyType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="call-property" type="jboss:call-propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="stub-propertyType">
+      <xsd:sequence>
+         <xsd:element name="prop-name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="prop-value" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="call-propertyType">
+      <xsd:sequence>
+         <xsd:element name="prop-name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+         <xsd:element name="prop-value" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="message-destinationType">
+      <xsd:annotation>
+         <xsd:documentation> The message-destination element is used to configure the jndi-name for a
+            message-destination in ejb-jar.xml Used in: assembly-descriptor </xsd:documentation>
+      </xsd:annotation>
+
+      <xsd:sequence>
+         <xsd:group ref="jboss:descriptionGroup"/>
+         <xsd:element name="message-destination-name" type="jakartaee:xsdStringType"/>
+         <xsd:choice>
+            <xsd:element name="jndi-name" type="jakartaee:xsdStringType"/>
+            <xsd:element name="mapped-name" type="jakartaee:xsdStringType"/>
+         </xsd:choice>
+         <xsd:element name="lookup-name" type="jakartaee:xsdStringType"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="webservice-descriptionType">
+      <xsd:annotation>
+         <xsd:documentation>
+            <![CDATA[
+            Runtime information about a web service.
+            wsdl-publish-location is optionally used to specify
+            where the final wsdl and any dependent files should be stored.  This location
+            resides on the file system from which deployment is initiated.
+            ]]>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="webservice-description-name" type="xsd:string"/>
+         <xsd:element name="config-name" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="config-file" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="wsdl-publish-location" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:ID" />
+   </xsd:complexType>
+
+</xsd:schema>

--- a/common/src/main/resources/schema/jboss-common_11_0.xsd
+++ b/common/src/main/resources/schema/jboss-common_11_0.xsd
@@ -1,20 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ JBoss, Home of Professional Open Source
-~ Copyright 2022, Red Hat, Inc., and individual contributors as indicated
-~ by the @authors tag.
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~ http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
+  Copyright The JBoss Metadata Authors
+  SPDX-License-Identifier: Apache-2.0
 -->
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="urn:jboss:jakartaee:1.0"

--- a/common/src/test/java/org/jboss/test/metadata/javaee/AbstractJavaEEEverythingTest.java
+++ b/common/src/test/java/org/jboss/test/metadata/javaee/AbstractJavaEEEverythingTest.java
@@ -558,7 +558,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertDataSources(String prefix, DataSourcesMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if ((version != JavaEEVersion.V7 && version != JavaEEVersion.V8 && version != JavaEEVersion.V9 && version != JavaEEVersion.V10) || !full) {
+        if ((version != JavaEEVersion.V7 && version != JavaEEVersion.V8 && version != JavaEEVersion.V9 && version != JavaEEVersion.V10 && version != JavaEEVersion.V11) || !full) {
             assertNull(metaDatas);
             return;
         }
@@ -597,7 +597,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertAdministeredObjects(String prefix, AdministeredObjectsMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if ((version != JavaEEVersion.V7 && version != JavaEEVersion.V8 && version != JavaEEVersion.V9 && version != JavaEEVersion.V10) || !full) {
+        if ((version != JavaEEVersion.V7 && version != JavaEEVersion.V8 && version != JavaEEVersion.V9 && version != JavaEEVersion.V10 && version != JavaEEVersion.V11) || !full) {
             assertNull(metaDatas);
             return;
         }

--- a/common/src/test/java/org/jboss/test/metadata/javaee/AbstractJavaEEEverythingTest.java
+++ b/common/src/test/java/org/jboss/test/metadata/javaee/AbstractJavaEEEverythingTest.java
@@ -947,7 +947,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertContextServices(String prefix, ContextServicesMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if (version != JavaEEVersion.V10 || !full) {
+        if (version != JavaEEVersion.V10 && version != JavaEEVersion.V11 || !full) {
             assertNull(metaDatas);
             return;
         }
@@ -1007,7 +1007,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertManagedExecutors(String prefix, ManagedExecutorsMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if (version != JavaEEVersion.V10 || !full) {
+        if (version != JavaEEVersion.V10 && version != JavaEEVersion.V11 || !full) {
             assertNull(metaDatas);
             return;
         }
@@ -1068,7 +1068,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertManagedScheduledExecutors(String prefix, ManagedScheduledExecutorsMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if (version != JavaEEVersion.V10 || !full) {
+        if (version != JavaEEVersion.V10 && version != JavaEEVersion.V11 || !full) {
             assertNull(metaDatas);
             return;
         }
@@ -1129,7 +1129,7 @@ public abstract class AbstractJavaEEEverythingTest extends AbstractJavaEEMetaDat
     }
 
     protected void assertManagedThreadFactories(String prefix, ManagedThreadFactoriesMetaData metaDatas, Mode mode, boolean full, JavaEEVersion version) {
-        if (version != JavaEEVersion.V10 || !full) {
+        if (version != JavaEEVersion.V10 && version != JavaEEVersion.V11 || !full) {
             assertNull(metaDatas);
             return;
         }

--- a/ear/src/main/java/org/jboss/metadata/ear/spec/EarVersion.java
+++ b/ear/src/main/java/org/jboss/metadata/ear/spec/EarVersion.java
@@ -23,7 +23,8 @@ public enum EarVersion {
     APP_7_0("http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd", "7.0", JavaEEVersion.V7),
     APP_8_0("http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd", "8.0", JavaEEVersion.V8),
     APP_9_0("https://jakarta.ee/xml/ns/jakartaee/application_9.xsd", "9.0", JavaEEVersion.V9),
-    APP_10_0("https://jakarta.ee/xml/ns/jakartaee/application_10.xsd", "10.0", JavaEEVersion.V10);
+    APP_10_0("https://jakarta.ee/xml/ns/jakartaee/application_10.xsd", "10.0", JavaEEVersion.V10),
+    APP_11_0("https://jakarta.ee/xml/ns/jakartaee/application_11.xsd", "11.0", JavaEEVersion.V11);
 
     private static final Map<String, EarVersion> bindings = new HashMap<>();
 

--- a/ear/src/main/resources/schema/jboss-app_11_0.xsd
+++ b/ear/src/main/resources/schema/jboss-app_11_0.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source
+~ Copyright 2019, Red Hat, Inc., and individual contributors as indicated
+~ by the @authors tag.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<xs:schema xmlns="urn:jboss:jakartaee:1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+           xmlns:jboss="urn:jboss:jakartaee:1.0"
+           targetNamespace="urn:jboss:jakartaee:1.0"
+           version="11"
+           elementFormDefault="qualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            <![CDATA[
+
+    This is the XML Schema for the JBoss EAR application deployment descriptor.
+    The deployment descriptor must be named "jboss-app.xml" and placed in the
+    .ear/META-INF folder. All the descriptors must indicate
+    the JBoss schema by using the Jakarta EE namespace:
+
+        urn:jboss:jakartaee:1.0
+
+    and by indicating the version of the schema by
+    using the version attribute as shown below:
+
+        <jboss-app xmlns="urn:jboss:jakartaee:1.0"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             version="11">
+             ...
+        </jboss-app>
+
+    The instance documents may indicate the published version of
+    the schema using the xsi:schemaLocation attribute for the
+    Jakarta EE namespace with the following location:
+
+        https://www.jboss.org/schema/jbossas/jboss-app_11_0.xsd
+
+    ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Import the JakartaEE 11 xsd -->
+    <xs:import namespace="https://jakarta.ee/xml/ns/jakartaee"
+               schemaLocation="https://jakarta.ee/xml/ns/jakartaee/application_11.xsd"/>
+
+
+
+    <!-- Include the common JBoss EE elements -->
+    <xs:include schemaLocation="https://www.jboss.org/schema/jbossas/jboss-common_11_0.xsd"/>
+
+
+    <xs:element name="jboss-app" type="jboss-appType"/>
+
+    <xs:complexType name="jboss-appType">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for JBoss specific configurations in a .ear
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="jakartaee:applicationType">
+                <xs:sequence>
+                    <xs:element name="distinct-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The distinct-name for this application.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="security-domain" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The security domain application for this application.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="unauthenticated-principal" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The principal that will be used for unauthenticated requests in this application
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+
+                    <xs:element name="library-directory" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+                    <xs:element name="security-role" minOccurs="0" maxOccurs="unbounded"
+                                type="jboss:security-roleType"/>
+
+                    <xs:element name="module" minOccurs="0" maxOccurs="unbounded" type="moduleType"/>
+
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="moduleType">
+        <xs:complexContent>
+            <xs:extension base="jakartaee:moduleType">
+                <xs:sequence>
+                    <xs:element name="service" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="har" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="web" type="jakartaee:webType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/ear/src/main/resources/schema/jboss-app_11_0.xsd
+++ b/ear/src/main/resources/schema/jboss-app_11_0.xsd
@@ -1,20 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ JBoss, Home of Professional Open Source
-~ Copyright 2019, Red Hat, Inc., and individual contributors as indicated
-~ by the @authors tag.
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~ http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
+  Copyright The JBoss Metadata Authors
+  SPDX-License-Identifier: Apache-2.0
 -->
 <xs:schema xmlns="urn:jboss:jakartaee:1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/ear/src/test/java/org/jboss/test/metadata/ear/Ear11xEverythingUnitTestCase.java
+++ b/ear/src/test/java/org/jboss/test/metadata/ear/Ear11xEverythingUnitTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The JBoss Metadata Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.test.metadata.ear;
+
+import org.jboss.metadata.ear.parser.spec.EarMetaDataParser;
+import org.jboss.metadata.ear.spec.ConnectorModuleMetaData;
+import org.jboss.metadata.ear.spec.EarEnvironmentRefsGroupMetaData;
+import org.jboss.metadata.ear.spec.EarMetaData;
+import org.jboss.metadata.ear.spec.EarVersion;
+import org.jboss.metadata.ear.spec.EjbModuleMetaData;
+import org.jboss.metadata.ear.spec.JavaModuleMetaData;
+import org.jboss.metadata.ear.spec.ModuleMetaData;
+import org.jboss.metadata.ear.spec.ModulesMetaData;
+import org.jboss.metadata.ear.spec.WebModuleMetaData;
+import org.jboss.test.metadata.javaee.AbstractJavaEEEverythingTest;
+
+/**
+ * Ear10x tests.
+ *
+ * @author Brian Stansberry
+ */
+public class Ear11xEverythingUnitTestCase extends AbstractJavaEEEverythingTest {
+
+    protected EarMetaData unmarshal() throws Exception {
+        final EarMetaData earMetaData = EarMetaDataParser.INSTANCE.parse(getReader());
+        assertTrue(earMetaData instanceof  EarMetaData);
+        return EarMetaData.class.cast(earMetaData);
+    }
+
+    protected EarVersion getExpectedEarVersion() {
+        return EarVersion.APP_11_0;
+    }
+
+    public void testEverything() throws Exception {
+        EarMetaData result = unmarshal();
+
+        assertEquals("application-test-everything", result.getId());
+        assertEquals(getExpectedEarVersion(), result.getEarVersion());
+        assertEquals("ApplicationName", result.getApplicationName());
+
+        String prefix = "app";
+        final Mode mode = Mode.SPEC;
+
+        assertDescriptionGroup(prefix, result.getDescriptionGroup());
+        assertSecurityRoles(2,result.getSecurityRoles(), mode);
+        assertLibraryDirectory(result);
+        assertModules(result);
+        assertTrue(result.getInitializeInOrder());
+        assertEarEnvironment(prefix,result.getEarEnvironmentRefsGroup(), result.getEarVersion(), mode);
+    }
+
+    protected void assertEarEnvironment(String prefix, EarEnvironmentRefsGroupMetaData earEnvironmentRefsGroup, EarVersion earVersion, Mode mode) {
+        assertNotNull(earEnvironmentRefsGroup);
+        final boolean full = true;
+        assertEnvironment(prefix, earEnvironmentRefsGroup, full, Descriptor.APPLICATION, mode, earVersion.getJavaEEVersion());
+        assertMessageDestinations(2,earEnvironmentRefsGroup.getMessageDestinations(),mode, earVersion.getJavaEEVersion());
+    }
+
+    protected void assertLibraryDirectory(EarMetaData ear) {
+        assertEquals("lib0", ear.getLibraryDirectory());
+    }
+
+    protected void assertModules(EarMetaData ear) {
+        ModulesMetaData modules = ear.getModules();
+        assertEquals(6, modules.size());
+        ModuleMetaData connector = modules.get(0);
+        assertEquals("connector0", connector.getId());
+        assertEquals("META-INF/alt-ra.xml", connector.getAlternativeDD());
+        ConnectorModuleMetaData connectorMD = (ConnectorModuleMetaData) connector.getValue();
+        assertEquals("rar0.rar", connectorMD.getConnector());
+        ModuleMetaData java = modules.get(1);
+        assertEquals("java0", java.getId());
+        assertEquals("META-INF/alt-application-client.xml", java.getAlternativeDD());
+        JavaModuleMetaData javaMD = (JavaModuleMetaData) java.getValue();
+        assertEquals("client0.jar", javaMD.getClientJar());
+        ModuleMetaData ejb0 = modules.get(2);
+        assertEquals("ejb0", ejb0.getId());
+        assertEquals("META-INF/alt-ejb-jar.xml", ejb0.getAlternativeDD());
+        EjbModuleMetaData ejb0MD = (EjbModuleMetaData) ejb0.getValue();
+        assertEquals("ejb-jar0.jar", ejb0MD.getEjbJar());
+        ModuleMetaData ejb1 = modules.get(3);
+        assertEquals("ejb1", ejb1.getId());
+        assertEquals("META-INF/alt-ejb-jar.xml", ejb1.getAlternativeDD());
+        EjbModuleMetaData ejb1MD = (EjbModuleMetaData) ejb1.getValue();
+        assertEquals("ejb-jar1.jar", ejb1MD.getEjbJar());
+        ModuleMetaData web0 = modules.get(4);
+        assertEquals("web0", web0.getId());
+        assertEquals("WEB-INF/alt-web.xml", web0.getAlternativeDD());
+        WebModuleMetaData web0MD = (WebModuleMetaData) web0.getValue();
+        assertEquals("/web0", web0MD.getContextRoot());
+        assertEquals("web-app0.war", web0MD.getWebURI());
+        ModuleMetaData web1 = modules.get(5);
+        assertEquals("web1", web1.getId());
+        assertEquals("WEB-INF/alt-web.xml", web1.getAlternativeDD());
+        WebModuleMetaData web1MD = (WebModuleMetaData) web1.getValue();
+        assertEquals("/web1", web1MD.getContextRoot());
+        assertEquals("web-app1.war", web1MD.getWebURI());
+    }
+}

--- a/ear/src/test/java/org/jboss/test/metadata/ear/JBossApp11xEverythingUnitTestCase.java
+++ b/ear/src/test/java/org/jboss/test/metadata/ear/JBossApp11xEverythingUnitTestCase.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright The JBoss Metadata Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.test.metadata.ear;
+
+import org.jboss.metadata.ear.jboss.JBossAppMetaData;
+import org.jboss.metadata.ear.jboss.ServiceModuleMetaData;
+import org.jboss.metadata.ear.merge.JBossAppMetaDataMerger;
+import org.jboss.metadata.ear.parser.jboss.JBossAppMetaDataParser;
+import org.jboss.metadata.ear.parser.spec.EarMetaDataParser;
+import org.jboss.metadata.ear.spec.ConnectorModuleMetaData;
+import org.jboss.metadata.ear.spec.EarMetaData;
+import org.jboss.metadata.ear.spec.EjbModuleMetaData;
+import org.jboss.metadata.ear.spec.JavaModuleMetaData;
+import org.jboss.metadata.ear.spec.ModuleMetaData;
+import org.jboss.metadata.ear.spec.ModulesMetaData;
+import org.jboss.metadata.ear.spec.WebModuleMetaData;
+import org.jboss.metadata.javaee.spec.SecurityRoleMetaData;
+import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
+import org.jboss.test.metadata.javaee.AbstractJavaEEMetaDataTest;
+import org.junit.Test;
+
+/**
+ * Test jboss-app.xml which uses jboss-app_11_0.xsd
+ *
+ * @author Jaikiran Pai
+ */
+public class JBossApp11xEverythingUnitTestCase extends AbstractJavaEEMetaDataTest {
+
+    private boolean hasJBossAppOverride = false;
+
+    protected JBossAppMetaData unmarshal() throws Exception {
+        return JBossAppMetaDataParser.INSTANCE.parse(getReader());
+    }
+
+    @Test
+    public void testOverride() throws Exception {
+        EarMetaData spec = EarMetaDataParser.INSTANCE.parse(getReader("Ear11xEverything_testEverything.xml"));
+        JBossAppMetaData jbossAppMD = new JBossAppMetaData();
+        JBossAppMetaDataMerger.merge(jbossAppMD, null, spec);
+        hasJBossAppOverride = false;
+        assertEveryting(jbossAppMD);
+    }
+
+    @Test
+    public void testEverything()
+            throws Exception {
+        //enableTrace("org.jboss.xb");
+        EarMetaData spec = EarMetaDataParser.INSTANCE.parse(getReader("Ear11xEverything_testEverything.xml"));
+        JBossAppMetaData jbossAppXml = unmarshal();
+        assertEquals("Unexpected distinct-name", "foo", jbossAppXml.getDistinctName());
+        JBossAppMetaData jbossAppMD = new JBossAppMetaData();
+        JBossAppMetaDataMerger.merge(jbossAppMD, jbossAppXml, spec);
+        hasJBossAppOverride = true;
+        assertEveryting(jbossAppMD);
+        assertEquals("jboss-app-id", jbossAppMD.getId());
+        assertEveryting(jbossAppMD);
+    }
+
+    protected void assertEveryting(JBossAppMetaData ear) throws Exception {
+        assertSecurityRoles(ear);
+        assertLibraryDirectory(ear);
+        assertModules(ear);
+    }
+
+    protected void assertSecurityRoles(JBossAppMetaData ear) {
+        SecurityRolesMetaData roles = ear.getSecurityRoles();
+        assertEquals("There are 2 roles " + roles, 2, roles.size());
+        SecurityRoleMetaData role0 = roles.get("securityRoleRef1RoleLink");
+        SecurityRoleMetaData role1 = roles.get("securityRoleRef2RoleLink");
+        if (hasJBossAppOverride) {
+            assertEquals("security-role0", role0.getId());
+            assertEquals("securityRoleRef1RoleLink", role0.getName());
+            assertEquals("en-securityRole1-desc", role0.getDescriptions().value()[0].value());
+
+            assertEquals("security-role1", role1.getId());
+            assertEquals("securityRoleRef2RoleLink", role1.getName());
+            assertEquals("en-securityRole2-desc", role1.getDescriptions().value()[0].value());
+
+            assertTrue("1 principal in role0", role0.getPrincipals().size() == 1);
+            assertEquals("principal0", role0.getPrincipals().toArray()[0]);
+            assertEquals("principal1", role1.getPrincipals().toArray()[0]);
+        } else {
+            assertEquals("securityRole1-id", role0.getId());
+            assertEquals("securityRoleRef1RoleLink", role0.getName());
+            assertEquals("en-securityRole1-desc", role0.getDescriptions().value()[0].value());
+
+            assertEquals("securityRole2-id", role1.getId());
+            assertEquals("securityRoleRef2RoleLink", role1.getName());
+            assertEquals("en-securityRole2-desc", role1.getDescriptions().value()[0].value());
+        }
+    }
+
+    protected void assertLibraryDirectory(JBossAppMetaData ear) {
+        if (hasJBossAppOverride) {
+            assertEquals("jboss-app-lib0", ear.getLibraryDirectory());
+        } else {
+            assertEquals("lib0", ear.getLibraryDirectory());
+        }
+    }
+
+    protected void assertModules(JBossAppMetaData ear) {
+        ModulesMetaData modules = ear.getModules();
+        if (hasJBossAppOverride) {
+            assertEquals(9, modules.size());
+        } else {
+            assertEquals(6, modules.size());
+        }
+        ModuleMetaData connector = modules.get(0);
+        assertEquals("connector0", connector.getId());
+        ConnectorModuleMetaData connectorMD = (ConnectorModuleMetaData) connector.getValue();
+        assertEquals("rar0.rar", connectorMD.getConnector());
+        ModuleMetaData java = modules.get(1);
+        assertEquals("java0", java.getId());
+        JavaModuleMetaData javaMD = (JavaModuleMetaData) java.getValue();
+        assertEquals("client0.jar", javaMD.getClientJar());
+        ModuleMetaData ejb0 = modules.get(2);
+        assertEquals("ejb0", ejb0.getId());
+        EjbModuleMetaData ejb0MD = (EjbModuleMetaData) ejb0.getValue();
+        assertEquals("ejb-jar0.jar", ejb0MD.getEjbJar());
+        ModuleMetaData ejb1 = modules.get(3);
+        assertEquals("ejb1", ejb1.getId());
+        EjbModuleMetaData ejb1MD = (EjbModuleMetaData) ejb1.getValue();
+        assertEquals("ejb-jar1.jar", ejb1MD.getEjbJar());
+        ModuleMetaData web0 = modules.get(4);
+        assertEquals("web0", web0.getId());
+        WebModuleMetaData web0MD = (WebModuleMetaData) web0.getValue();
+        assertEquals("/web0", web0MD.getContextRoot());
+        assertEquals("web-app0.war", web0MD.getWebURI());
+        ModuleMetaData web1 = modules.get(5);
+        assertEquals("web1", web1.getId());
+        WebModuleMetaData web1MD = (WebModuleMetaData) web1.getValue();
+        if (hasJBossAppOverride) {
+            assertEquals("/web1-override", web1MD.getContextRoot());
+        } else {
+            assertEquals("/web1", web1MD.getContextRoot());
+        }
+        assertEquals("web-app1.war", web1MD.getWebURI());
+        if (hasJBossAppOverride) {
+            // Validate the sar, web2, har added in jboss-app.xml
+            ModuleMetaData sar = modules.get(6);
+            assertEquals("sar0", sar.getId());
+            ServiceModuleMetaData sarMD = (ServiceModuleMetaData) sar.getValue();
+            assertEquals("sar0.sar", sarMD.getSar());
+            ModuleMetaData web2 = modules.get(7);
+            assertEquals("web2", web2.getId());
+            WebModuleMetaData web2MD = (WebModuleMetaData) web2.getValue();
+            assertEquals("/web2", web2MD.getContextRoot());
+            assertEquals("web-app2.war", web2MD.getWebURI());
+            ModuleMetaData har = modules.get(8);
+            assertEquals("har0", har.getId());
+            ServiceModuleMetaData harMD = (ServiceModuleMetaData) har.getValue();
+            assertEquals("har0.har", harMD.getSar());
+        }
+        // Validate lookup by module file name
+        ModuleMetaData mmd = modules.get("rar0.rar");
+        assertEquals(connector, mmd);
+        mmd = modules.get("ejb-jar1.jar");
+        assertEquals(ejb1, mmd);
+        mmd = modules.get("web-app0.war");
+        assertEquals(web0, mmd);
+    }
+}

--- a/ear/src/test/resources/org/jboss/test/metadata/ear/JBossApp11xEverything_testEverything.xml
+++ b/ear/src/test/resources/org/jboss/test/metadata/ear/JBossApp11xEverything_testEverything.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The JBoss Metadata Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<jboss-app xmlns="urn:jboss:jakartaee:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:jboss:jakartaee:1.0 https://www.jboss.org/schema/jbossas/jboss-app_11_0.xsd"
+           version="11"
+           id="jboss-app-id">
+
+    <distinct-name>foo</distinct-name>
+    <library-directory>jboss-app-lib0</library-directory>
+
+    <!-- Add a sar0 module -->
+    <module id="sar0">
+        <service>sar0.sar</service>
+    </module>
+    <!-- Override the web1 context-root -->
+    <module id="web1">
+        <web>
+            <web-uri>web-app1.war</web-uri>
+            <context-root>/web1-override</context-root>
+        </web>
+    </module>
+    <!-- Add a web2 module -->
+    <module id="web2">
+        <web>
+            <web-uri>web-app2.war</web-uri>
+            <context-root>/web2</context-root>
+        </web>
+    </module>
+    <module id="har0">
+        <har>har0.har</har>
+    </module>
+    <security-role id="security-role0">
+        <description>The 0 security role</description>
+        <role-name>securityRoleRef1RoleLink</role-name>
+        <principal-name>principal0</principal-name>
+    </security-role>
+    <security-role id="security-role1">
+        <description>The 1 security role</description>
+        <role-name>securityRoleRef2RoleLink</role-name>
+        <principal-name>principal1</principal-name>
+    </security-role>
+</jboss-app>


### PR DESCRIPTION
…sue: https://issues.redhat.com/browse/JBMETA-458

NOTE:
The current application-client_11.xsd included in this PR cannot be used to validate xml files due to a bug in this file.

I opened https://github.com/jakartaee/jakarta.ee/issues/2199 to track it down, although I am not 100% sure if that repository is the correct one to fix these issues.

We can delay merging this , file a follow-up JBMETA Jira to address this issue once the changes have been fixed by Jakarta EE side, or temporarily fix it here, although I leave it as it is since this doesn't affect our tests.